### PR TITLE
AutoIt: support end field

### DIFF
--- a/Units/parser-autoit.r/simple-au3.d/args.ctags
+++ b/Units/parser-autoit.r/simple-au3.d/args.ctags
@@ -1,2 +1,2 @@
---fields=+rS
+--fields=+rSe
 --extras=+r

--- a/Units/parser-autoit.r/simple-au3.d/expected.tags
+++ b/Units/parser-autoit.r/simple-au3.d/expected.tags
@@ -1,10 +1,10 @@
 $iDoubled	input.au3	/^Local $iDoubled = 0$/;"	l	roles:def
 $iNumber	input.au3	/^Local $iNumber = 10$/;"	l	roles:def
 $iSomething	input.au3	/^    Local $iSomething = 42$/;"	l	func:All functions.MyDouble0	roles:def
-All functions	input.au3	/^#Region All functions$/;"	r	roles:def
+All functions	input.au3	/^#Region All functions$/;"	r	roles:def	end:44
 Constants.au3	input.au3	/^#include <Constants.au3>$/;"	S	roles:system
 GUIConstantsEx.au3	input.au3	/^#include<GUIConstantsEx.au3>$/;"	S	roles:system
-MyDouble	input.au3	/^Func MyDouble($iValue)$/;"	f	region:All functions	signature:($iValue)	roles:def
-MyDouble0	input.au3	/^func MyDouble0($iValue)$/;"	f	region:All functions	signature:($iValue)	roles:def
-MyDouble1	input.au3	/^    	FUNC MyDouble1($iValue)$/;"	f	region:All functions	signature:($iValue)	roles:def
+MyDouble	input.au3	/^Func MyDouble($iValue)$/;"	f	region:All functions	signature:($iValue)	roles:def	end:32
+MyDouble0	input.au3	/^func MyDouble0($iValue)$/;"	f	region:All functions	signature:($iValue)	roles:def	end:38
+MyDouble1	input.au3	/^    	FUNC MyDouble1($iValue)$/;"	f	region:All functions	signature:($iValue)	roles:def	end:43
 WindowsConstants.au3	input.au3	/^#include "WindowsConstants.au3"$/;"	S	roles:local

--- a/parsers/autoit.c
+++ b/parsers/autoit.c
@@ -104,6 +104,17 @@ static int makeSimpleAutoItTag (const NestingLevels *const nls,
 	return makeAutoItTag (nls, name, kindIndex, NULL);
 }
 
+static void attachEndField (const NestingLevels *const nls)
+{
+	NestingLevel *nl = nestingLevelsGetCurrent (nls);
+	if (nl)
+	{
+		tagEntryInfo *e;
+		e = getEntryInCorkQueue (nl->corkIndex);
+		e->extensionFields.endLine = getInputLineNumber ();
+	}
+}
+
 static void findAutoItTags (void)
 {
 	vString *name = vStringNew ();
@@ -143,7 +154,10 @@ static void findAutoItTags (void)
 				}
 			}
 			else if (match (p, "endregion"))
+			{
+				attachEndField (nls);
 				nestingLevelsPop (nls);
+			}
 			else if (match (p, "include"))
 			{
 				p += 7; /* strlen("include") = 7 */
@@ -206,7 +220,10 @@ static void findAutoItTags (void)
 				}
 			}
 			else if (match (p, "endfunc"))
+			{
+				attachEndField (nls);
 				nestingLevelsPop (nls);
+			}
 			else if ((isGlobal = match (p, "global")) || match (p, "local"))
 			{
 				p += isGlobal ? 6 : 5;


### PR DESCRIPTION
If a parser can track scopes, it can emit end: field.